### PR TITLE
Gz/ai pr test

### DIFF
--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -1,0 +1,30 @@
+name: Code Review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+  pull_request_review_comment:
+    types: [created]
+
+concurrency:
+  group:
+    ${{ github.repository }}-${{ github.event.number || github.head_ref ||
+    github.sha }}-${{ github.workflow }}-${{ github.event_name ==
+    'pull_request_review_comment' && 'pr_comment' || 'pr' }}
+  cancel-in-progress: ${{ github.event_name != 'pull_request_review_comment' }}
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: coderabbitai/ai-pr-reviewer@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        with:
+          debug: false
+          review_simple_changes: false
+          review_comment_lgtm: false

--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: huangmin-ms/ai-pr-reviewer
-          ref: main
+          ref: azure-bot
           submodules: false
       - uses: ./
         env:
@@ -35,4 +35,4 @@ jobs:
           review_simple_changes: false
           review_comment_lgtm: false
           path_filters: |
-            yml/**/*.yml
+            yml/**/azure.storage.blob.AccessPolicy.yml

--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -34,5 +34,6 @@ jobs:
           debug: true
           review_simple_changes: false
           review_comment_lgtm: false
+          openai_light_model: gpt-35-turbo
           path_filters: |
             yml/**/azure.storage.blob.BlobServiceClient.yml

--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -35,5 +35,6 @@ jobs:
           review_simple_changes: false
           review_comment_lgtm: false
           openai_light_model: gpt-35-turbo
+          openai_retries: 1
           path_filters: |
             yml/**/azure.storage.blob.BlobServiceClient.yml

--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -29,9 +29,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_BASE_URL: ${{ secrets.OPENAI_API_BASE_URL }}
         with:
           debug: true
-          openai_base_url: ${{ secrets.OPENAI_API_BASE_URL }}
           review_simple_changes: false
           review_comment_lgtm: false
           path_filters: |

--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -30,7 +30,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         with:
-          debug: false
+          debug: true
+          openai_base_url: ${{ secrets.OPENAI_API_BASE_URL }}
           review_simple_changes: false
           review_comment_lgtm: false
           path_filters: |

--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -37,4 +37,4 @@ jobs:
           openai_light_model: gpt-35-turbo
           openai_retries: 1
           path_filters: |
-            yml/**/azure.storage.blob.BlobLeaseClient.yml
+            yml/**/*.yml

--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -37,4 +37,4 @@ jobs:
           openai_light_model: gpt-35-turbo
           openai_retries: 1
           path_filters: |
-            yml/**/*.yml
+            yml/**/azure.storage.blob.BlobClient.yml

--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -28,3 +28,4 @@ jobs:
           debug: false
           review_simple_changes: false
           review_comment_lgtm: false
+          path_filters: "yml/**/*.yml"

--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -37,4 +37,4 @@ jobs:
           openai_light_model: gpt-35-turbo
           openai_retries: 1
           path_filters: |
-            yml/**/azure.storage.blob.BlobClient.yml
+            yml/**/azure.storage.blob.BlobLeaseClient.yml

--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -37,4 +37,4 @@ jobs:
           openai_light_model: gpt-35-turbo
           openai_retries: 1
           path_filters: |
-            yml/**/azure.storage.blob.BlobServiceClient.yml
+            yml/**/*.yml

--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -35,4 +35,4 @@ jobs:
           review_simple_changes: false
           review_comment_lgtm: false
           path_filters: |
-            yml/**/azure.storage.blob.AccessPolicy.yml
+            yml/**/azure.storage.blob.BlobServiceClient.yml

--- a/.github/workflows/ai-pr-reviewer.yml
+++ b/.github/workflows/ai-pr-reviewer.yml
@@ -20,7 +20,12 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: coderabbitai/ai-pr-reviewer@latest
+      - uses: actions/checkout@v4
+        with:
+          repository: huangmin-ms/ai-pr-reviewer
+          ref: main
+          submodules: false
+      - uses: ./
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -28,4 +33,5 @@ jobs:
           debug: false
           review_simple_changes: false
           review_comment_lgtm: false
-          path_filters: "yml/**/*.yml"
+          path_filters: |
+            yml/**/*.yml

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.ArrowType.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.ArrowType.yml
@@ -2,10 +2,10 @@
 uid: azure.storage.blob.ArrowType
 name: ArrowType
 fullName: azure.storage.blob.ArrowType
-summary: An enumeration.
 module: azure.storage.blob
 constructor:
-  syntax: ArrowType(value)
+  syntax: ArrowType(value, names=None, *, module=None, qualname=None, type=None, start=1,
+    boundary=None)
 inheritances:
 - builtins.str
 - enum.Enum

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobBlock.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobBlock.yml
@@ -7,7 +7,7 @@ inheritances:
 - azure.storage.blob._shared.models.DictMixin
 summary: BlockBlob Block class.
 constructor:
-  syntax: 'BlobBlock(block_id, state=<BlockState.LATEST: ''Latest''>)'
+  syntax: BlobBlock(block_id, state=BlockState.LATEST)
   parameters:
   - name: block_id
     description: Block id.

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobClient.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobClient.yml
@@ -154,8 +154,8 @@ methods:
     This will leave a destination blob with zero length and full metadata.
 
     This will raise an error if the copy operation has already ended.'
-  signature: 'abort_copy(copy_id: Union[str, Dict[str, Any], azure.storage.blob._models.BlobProperties],
-    **kwargs: Any) -> None'
+  signature: 'abort_copy(copy_id: str | Dict[str, Any] | BlobProperties, **kwargs:
+    Any) -> None'
   parameters:
   - name: copy_id
     description: 'The copy operation to abort. This can be either an ID string, or
@@ -188,8 +188,8 @@ methods:
     If the blob does not have an active lease, the Blob
 
     Service creates a lease on the blob and returns a new lease.'
-  signature: 'acquire_lease(lease_duration: int = - 1, lease_id: Optional[str] = None,
-    **kwargs: Any) -> azure.storage.blob._lease.BlobLeaseClient'
+  signature: 'acquire_lease(lease_duration: int = -1, lease_id: str | None = None,
+    **kwargs: Any) -> BlobLeaseClient'
   parameters:
   - name: lease_duration
     description: 'Specifies the duration of the lease, in seconds, or negative one
@@ -277,8 +277,8 @@ methods:
 - uid: azure.storage.blob.BlobClient.append_block
   name: append_block
   summary: Commits a new block of data to the end of the existing append blob.
-  signature: 'append_block(data: Union[bytes, str, Iterable[AnyStr], IO[AnyStr]],
-    length: Optional[int] = None, **kwargs) -> Dict[str, Union[str, datetime, int]]'
+  signature: 'append_block(data: bytes | str | Iterable[AnyStr] | IO[AnyStr], length:
+    int | None = None, **kwargs) -> Dict[str, str | datetime | int]'
   parameters:
   - name: data
     description: Content of the block. This can be bytes, text, an iterable or a file-like
@@ -428,9 +428,9 @@ methods:
   name: append_block_from_url
   summary: Creates a new block to be committed as part of a blob, where the contents
     are read from a source url.
-  signature: 'append_block_from_url(copy_source_url: str, source_offset: Optional[int]
-    = None, source_length: Optional[int] = None, **kwargs) -> Dict[str, Union[str,
-    datetime, int]]'
+  signature: 'append_block_from_url(copy_source_url: str, source_offset: int | None
+    = None, source_length: int | None = None, **kwargs) -> Dict[str, str | datetime
+    | int]'
   parameters:
   - name: copy_source_url
     description: 'The URL of the source data. It can point to any Azure Blob or File,
@@ -612,8 +612,8 @@ methods:
 - uid: azure.storage.blob.BlobClient.clear_page
   name: clear_page
   summary: Clears a range of pages.
-  signature: 'clear_page(offset: int, length: int, **kwargs: Any) -> Dict[str, Union[str,
-    datetime]]'
+  signature: 'clear_page(offset: int, length: int, **kwargs: Any) -> Dict[str, str
+    | datetime]'
   parameters:
   - name: offset
     description: 'Start of byte range to use for writing to a section of the blob.
@@ -737,9 +737,9 @@ methods:
   summary: 'The Commit Block List operation writes a blob by specifying the list of
 
     block IDs that make up the blob.'
-  signature: 'commit_block_list(block_list: List[BlobBlock], content_settings: Optional[ContentSettings]
-    = None, metadata: Optional[Dict[str, str]] = None, **kwargs) -> Dict[str, Union[str,
-    datetime]]'
+  signature: 'commit_block_list(block_list: List[BlobBlock], content_settings: ContentSettings
+    | None = None, metadata: Dict[str, str] | None = None, **kwargs) -> Dict[str,
+    str | datetime]'
   parameters:
   - name: block_list
     description: List of Blockblobs.
@@ -902,9 +902,8 @@ methods:
 - uid: azure.storage.blob.BlobClient.create_append_blob
   name: create_append_blob
   summary: Creates a new Append Blob.
-  signature: 'create_append_blob(content_settings: Optional[ContentSettings] = None,
-    metadata: Optional[Dict[str, str]] = None, **kwargs: Any) -> Dict[str, Union[str,
-    datetime]]'
+  signature: 'create_append_blob(content_settings: ContentSettings | None = None,
+    metadata: Dict[str, str] | None = None, **kwargs: Any) -> Dict[str, str | datetime]'
   parameters:
   - name: content_settings
     description: 'ContentSettings object used to set blob properties. Used to set
@@ -1033,9 +1032,9 @@ methods:
 - uid: azure.storage.blob.BlobClient.create_page_blob
   name: create_page_blob
   summary: Creates a new Page Blob of the specified size.
-  signature: 'create_page_blob(size: int, content_settings: Optional[ContentSettings]
-    = None, metadata: Optional[Dict[str, str]] = None, premium_page_blob_tier: Optional[Union[str,
-    PremiumPageBlobTier]] = None, **kwargs) -> Dict[str, Union[str, datetime]]'
+  signature: 'create_page_blob(size: int, content_settings: ContentSettings | None
+    = None, metadata: Dict[str, str] | None = None, premium_page_blob_tier: str |
+    PremiumPageBlobTier | None = None, **kwargs) -> Dict[str, str | datetime]'
   parameters:
   - name: size
     description: 'This specifies the maximum size for the page blob, up to 1 TB.
@@ -1204,8 +1203,8 @@ methods:
     is taken, with a DateTime value appended to indicate the time at which the
 
     snapshot was taken.'
-  signature: 'create_snapshot(metadata: Optional[Dict[str, str]] = None, **kwargs:
-    Any) -> Dict[str, Union[str, datetime]]'
+  signature: 'create_snapshot(metadata: Dict[str, str] | None = None, **kwargs: Any)
+    -> Dict[str, str | datetime]'
   parameters:
   - name: metadata
     description: Name-value pairs associated with the blob as metadata.
@@ -1766,7 +1765,7 @@ methods:
   summary: 'Returns all user-defined metadata, standard HTTP properties, and
 
     system properties for the blob. It does not return the content of the blob.'
-  signature: 'get_blob_properties(**kwargs: Any) -> azure.storage.blob._models.BlobProperties'
+  signature: 'get_blob_properties(**kwargs: Any) -> BlobProperties'
   parameters:
   - name: lease
     description: 'Required if the blob has an active lease. Value can be a BlobLeaseClient
@@ -1902,8 +1901,8 @@ methods:
   summary: 'The Get Block List operation retrieves the list of blocks that have
 
     been uploaded as part of a block blob.'
-  signature: 'get_block_list(block_list_type: Optional[str] = ''committed'', **kwargs:
-    Any) -> Tuple[List[azure.storage.blob._models.BlobBlock], List[azure.storage.blob._models.BlobBlock]]'
+  signature: 'get_block_list(block_list_type: str | None = ''committed'', **kwargs:
+    Any) -> Tuple[List[BlobBlock], List[BlobBlock]]'
   parameters:
   - name: block_list_type
     description: 'Specifies whether to return the list of committed
@@ -1952,7 +1951,7 @@ methods:
 
     New in version 12.2.0: This operation was introduced in API version ''2019-07-07''.'
   signature: 'get_page_range_diff_for_managed_disk(previous_snapshot_url: str, offset:
-    Optional[int] = None, length: Optional[int] = None, **kwargs) -> Tuple[List[Dict[str,
+    int | None = None, length: int | None = None, **kwargs) -> Tuple[List[Dict[str,
     int]], List[Dict[str, int]]]'
   parameters:
   - name: previous_snapshot_url
@@ -2053,9 +2052,9 @@ methods:
   summary: 'DEPRECATED: Returns the list of valid page ranges for a Page Blob or snapshot
 
     of a page blob.'
-  signature: 'get_page_ranges(offset: Optional[int] = None, length: Optional[int]
-    = None, previous_snapshot_diff: Optional[Union[str, Dict[str, Any]]] = None, **kwargs)
-    -> Tuple[List[Dict[str, int]], List[Dict[str, int]]]'
+  signature: 'get_page_ranges(offset: int | None = None, length: int | None = None,
+    previous_snapshot_diff: str | Dict[str, Any] | None = None, **kwargs) -> Tuple[List[Dict[str,
+    int]], List[Dict[str, int]]]'
   parameters:
   - name: offset
     description: 'Start of byte range to use for getting valid page ranges.
@@ -2169,9 +2168,9 @@ methods:
     of a page blob. If *previous_snapshot* is specified, the result will be
 
     a diff of changes between the target blob and the previous snapshot.'
-  signature: 'list_page_ranges(*, offset: Optional[int] = None, length: Optional[int]
-    = None, previous_snapshot: Optional[Union[str, Dict[str, Any]]] = None, **kwargs:
-    Any) -> azure.core.paging.ItemPaged[azure.storage.blob._models.PageRange]'
+  signature: 'list_page_ranges(*, offset: int | None = None, length: int | None =
+    None, previous_snapshot: str | Dict[str, Any] | None = None, **kwargs: Any) ->
+    ItemPaged[PageRange]'
   parameters:
   - name: offset
     description: 'Start of byte range to use for getting valid page ranges.
@@ -2287,7 +2286,7 @@ methods:
 
     This operations returns a BlobQueryReader, users need to use readall() or readinto()
     to get query data.'
-  signature: 'query_blob(query_expression: str, **kwargs: Any) -> azure.storage.blob._quick_query_helper.BlobQueryReader'
+  signature: 'query_blob(query_expression: str, **kwargs: Any) -> BlobQueryReader'
   parameters:
   - name: query_expression
     description: Required. a query statement.
@@ -2430,7 +2429,7 @@ methods:
     If the specified value is less than the current size of the blob,
 
     then all pages above the specified value are cleared.'
-  signature: 'resize_blob(size: int, **kwargs: Any) -> Dict[str, Union[str, datetime]]'
+  signature: 'resize_blob(size: int, **kwargs: Any) -> Dict[str, str | datetime]'
   parameters:
   - name: size
     description: 'Size used to resize blob. Maximum size for a page blob is up to
@@ -2514,7 +2513,7 @@ methods:
   name: seal_append_blob
   summary: "The Seal operation seals the Append Blob to make it read-only.\n\n   New\
     \ in version 12.4.0."
-  signature: seal_append_blob(**kwargs) -> Dict[str, Union[str, datetime, int]]
+  signature: seal_append_blob(**kwargs) -> Dict[str, str | datetime | int]
   parameters:
   - name: appendpos_condition
     description: 'Optional conditional header, used only for the Append Block operation.
@@ -2583,8 +2582,8 @@ methods:
 - uid: azure.storage.blob.BlobClient.set_blob_metadata
   name: set_blob_metadata
   summary: Sets user-defined metadata for the blob as one or more name-value pairs.
-  signature: 'set_blob_metadata(metadata: Optional[Dict[str, str]] = None, **kwargs:
-    Any) -> Dict[str, Union[str, datetime]]'
+  signature: 'set_blob_metadata(metadata: Dict[str, str] | None = None, **kwargs:
+    Any) -> Dict[str, str | datetime]'
   parameters:
   - name: metadata
     description: 'Dict containing name and value pairs. Each call to this operation
@@ -2688,8 +2687,8 @@ methods:
     \ existing tags attached to the blob. To remove all\n   tags from the blob, call\
     \ this operation with no tags set.\n\nNew in version 12.4.0: This operation was\
     \ introduced in API version '2019-12-12'."
-  signature: 'set_blob_tags(tags: Optional[Dict[str, str]] = None, **kwargs: Any)
-    -> Dict[str, Any]'
+  signature: 'set_blob_tags(tags: Dict[str, str] | None = None, **kwargs: Any) ->
+    Dict[str, Any]'
   parameters:
   - name: tags
     description: 'Name-value pairs associated with the blob as tag. Tags are case-sensitive.
@@ -2756,8 +2755,8 @@ methods:
 
 
     If one property is set for the content_settings, all properties will be overridden.'
-  signature: 'set_http_headers(content_settings: Optional[ContentSettings] = None,
-    **kwargs: Any) -> None'
+  signature: 'set_http_headers(content_settings: ContentSettings | None = None, **kwargs:
+    Any) -> None'
   parameters:
   - name: content_settings
     description: 'ContentSettings object used to set blob properties. Used to set
@@ -2861,8 +2860,8 @@ methods:
 
 
     New in version 12.10.0: This operation was introduced in API version ''2020-10-02''.'
-  signature: 'set_legal_hold(legal_hold: bool, **kwargs: Any) -> Dict[str, Union[str,
-    datetime, bool]]'
+  signature: 'set_legal_hold(legal_hold: bool, **kwargs: Any) -> Dict[str, str | datetime
+    | bool]'
   parameters:
   - name: legal_hold
     description: Specified if a legal hold should be set on the blob.
@@ -2881,7 +2880,7 @@ methods:
   name: set_premium_page_blob_tier
   summary: Sets the page blob tiers on the blob. This API is only supported for page
     blobs on premium accounts.
-  signature: 'set_premium_page_blob_tier(premium_page_blob_tier: Union[str, PremiumPageBlobTier],
+  signature: 'set_premium_page_blob_tier(premium_page_blob_tier: str | PremiumPageBlobTier,
     **kwargs: Any) -> None'
   parameters:
   - name: premium_page_blob_tier
@@ -2926,9 +2925,8 @@ methods:
 - uid: azure.storage.blob.BlobClient.set_sequence_number
   name: set_sequence_number
   summary: Sets the blob sequence number.
-  signature: 'set_sequence_number(sequence_number_action: Union[str, SequenceNumberAction],
-    sequence_number: Optional[str] = None, **kwargs: Any) -> Dict[str, Union[str,
-    datetime]]'
+  signature: 'set_sequence_number(sequence_number_action: str | SequenceNumberAction,
+    sequence_number: str | None = None, **kwargs: Any) -> Dict[str, str | datetime]'
   parameters:
   - name: sequence_number_action
     description: 'This property indicates how the service should modify the blob''s
@@ -3017,8 +3015,8 @@ methods:
     A block blob''s tier determines Hot/Cool/Archive storage type.
 
     This operation does not update the blob''s ETag.'
-  signature: 'set_standard_blob_tier(standard_blob_tier: Union[str, StandardBlobTier],
-    **kwargs: Any) -> None'
+  signature: 'set_standard_blob_tier(standard_blob_tier: str | StandardBlobTier, **kwargs:
+    Any) -> None'
   parameters:
   - name: standard_blob_tier
     description: 'Indicates the tier to be set on the blob. Options include ''Hot'',
@@ -3081,8 +3079,8 @@ methods:
 - uid: azure.storage.blob.BlobClient.stage_block
   name: stage_block
   summary: Creates a new block to be committed as part of a blob.
-  signature: 'stage_block(block_id: str, data: Union[Iterable, IO], length: Optional[int]
-    = None, **kwargs) -> Dict[str, Any]'
+  signature: 'stage_block(block_id: str, data: Iterable | IO, length: int | None =
+    None, **kwargs) -> Dict[str, Any]'
   parameters:
   - name: block_id
     description: 'A string value that identifies the block.
@@ -3172,9 +3170,9 @@ methods:
   summary: 'Creates a new block to be committed as part of a blob where
 
     the contents are read from a URL.'
-  signature: 'stage_block_from_url(block_id: Union[str, int], source_url: str, source_offset:
-    Optional[int] = None, source_length: Optional[int] = None, source_content_md5:
-    Optional[Union[bytes, bytearray]] = None, **kwargs) -> Dict[str, Any]'
+  signature: 'stage_block_from_url(block_id: str | int, source_url: str, source_offset:
+    int | None = None, source_length: int | None = None, source_content_md5: bytes
+    | bytearray | None = None, **kwargs) -> Dict[str, Any]'
   parameters:
   - name: block_id
     description: 'A string value that identifies the block.
@@ -3315,9 +3313,8 @@ methods:
     end of the copy operation, the destination blob will have the same committed
 
     block count as the source.'
-  signature: 'start_copy_from_url(source_url: str, metadata: Optional[Dict[str, str]]
-    = None, incremental_copy: bool = False, **kwargs: Any) -> Dict[str, Union[str,
-    datetime]]'
+  signature: 'start_copy_from_url(source_url: str, metadata: Dict[str, str] | None
+    = None, incremental_copy: bool = False, **kwargs: Any) -> Dict[str, str | datetime]'
   parameters:
   - name: source_url
     description: 'A URL of up to 2 KB in length that specifies a file or blob.
@@ -3616,10 +3613,9 @@ methods:
 - uid: azure.storage.blob.BlobClient.upload_blob
   name: upload_blob
   summary: Creates a new blob from a data source with automatic chunking.
-  signature: 'upload_blob(data: Union[bytes, str, Iterable, IO], blob_type: Union[str,
-    azure.storage.blob._models.BlobType] = <BlobType.BLOCKBLOB: ''BlockBlob''>, length:
-    Optional[int] = None, metadata: Optional[Dict[str, str]] = None, **kwargs) ->
-    Any'
+  signature: 'upload_blob(data: bytes | str | Iterable | IO, blob_type: str | BlobType
+    = BlobType.BLOCKBLOB, length: int | None = None, metadata: Dict[str, str] | None
+    = None, **kwargs) -> Any'
   parameters:
   - name: data
     description: The blob data to upload.
@@ -4073,7 +4069,7 @@ methods:
   name: upload_page
   summary: The Upload Pages operation writes a range of pages to a page blob.
   signature: 'upload_page(page: bytes, offset: int, length: int, **kwargs) -> Dict[str,
-    Union[str, datetime]]'
+    str | datetime]'
   parameters:
   - name: page
     description: Content of the page.

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobImmutabilityPolicyMode.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobImmutabilityPolicyMode.yml
@@ -7,7 +7,8 @@ summary: 'Specifies the immutability policy mode to set on the blob.
   "Mutable" can only be returned by service, don''t set to "Mutable".'
 module: azure.storage.blob
 constructor:
-  syntax: BlobImmutabilityPolicyMode(value)
+  syntax: BlobImmutabilityPolicyMode(value, names=None, *, module=None, qualname=None,
+    type=None, start=1, boundary=None)
 inheritances:
 - builtins.str
 - enum.Enum

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobLeaseClient.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobLeaseClient.yml
@@ -10,7 +10,7 @@ summary: 'Creates a new BlobLeaseClient.
 
   This client provides lease operations on a BlobClient or ContainerClient.'
 constructor:
-  syntax: 'BlobLeaseClient(client: Union[BlobClient, ContainerClient], lease_id: Optional[str]
+  syntax: 'BlobLeaseClient(client: BlobClient | ContainerClient, lease_id: str | None
     = None)'
   parameters:
   - name: client
@@ -57,7 +57,7 @@ methods:
     If the container does not have an active lease, the Blob service creates a
 
     lease on the container and returns a new lease ID.'
-  signature: 'acquire(lease_duration: int = - 1, **kwargs: Any) -> None'
+  signature: 'acquire(lease_duration: int = -1, **kwargs: Any) -> None'
   parameters:
   - name: lease_duration
     description: 'Specifies the duration of the lease, in seconds, or negative one
@@ -140,8 +140,8 @@ methods:
     When a lease is successfully broken, the response indicates the interval
 
     in seconds until a new lease can be acquired.'
-  signature: 'break_lease(lease_break_period: Optional[int] = None, **kwargs: Any)
-    -> int'
+  signature: 'break_lease(lease_break_period: int | None = None, **kwargs: Any) ->
+    int'
   parameters:
   - name: lease_break_period
     description: 'This is the proposed duration of seconds that the lease

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobPrefix.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobPrefix.yml
@@ -111,7 +111,7 @@ methods:
 - uid: azure.storage.blob.BlobPrefix.by_page
   name: by_page
   summary: Get an iterator of pages of objects, instead of an iterator of objects.
-  signature: 'by_page(continuation_token: Optional[str] = None) -> Iterator[Iterator[ReturnType]]'
+  signature: 'by_page(continuation_token: str | None = None) -> Iterator[Iterator[ReturnType]]'
   parameters:
   - name: continuation_token
     description: 'An opaque continuation token. This value can be retrieved from the

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobProperties.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobProperties.yml
@@ -190,9 +190,9 @@ variables:
 
 
     New in version 12.4.0.'
-  name: str) tags
+  name: tags
   types:
-  - <xref:dict>(<xref:str,>
+  - <xref:dict>(<xref:str>, <xref:str>)
 - description: 'A true value indicates the root blob is deleted
 
 

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobQueryReader.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobQueryReader.yml
@@ -59,7 +59,7 @@ methods:
     If encoding has been configured - this will be used to decode individual
 
     records are they are received.'
-  signature: readall() -> Union[bytes, str]
+  signature: readall() -> bytes | str
   return:
     types:
     - <xref:Union>[<xref:bytes>, <xref:str>]
@@ -85,7 +85,7 @@ methods:
     If encoding has been configured - this will be used to decode individual
 
     records are they are received.'
-  signature: records() -> Iterable[Union[bytes, str]]
+  signature: records() -> Iterable[bytes | str]
   return:
     types:
     - <xref:Iterable>[<xref:Union>[<xref:bytes>, <xref:str>]]

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobServiceClient.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobServiceClient.yml
@@ -155,8 +155,8 @@ methods:
     be raised. This method returns a client with which to interact with the newly
 
     created container.'
-  signature: 'create_container(name: str, metadata: Optional[Dict[str, str]] = None,
-    public_access: Optional[Union[PublicAccess, str]] = None, **kwargs) -> ContainerClient'
+  signature: 'create_container(name: str, metadata: Dict[str, str] | None = None,
+    public_access: PublicAccess | str | None = None, **kwargs) -> ContainerClient'
   parameters:
   - name: name
     description: The name of the container to create.
@@ -213,8 +213,8 @@ methods:
     collection.
 
     If the container is not found, a ResourceNotFoundError will be raised.'
-  signature: 'delete_container(container: Union[ContainerProperties, str], lease:
-    Optional[Union[BlobLeaseClient, str]] = None, **kwargs) -> None'
+  signature: 'delete_container(container: ContainerProperties | str, lease: BlobLeaseClient
+    | str | None = None, **kwargs) -> None'
   parameters:
   - name: container
     description: 'The container to delete. This can either be the name of the container,
@@ -390,8 +390,8 @@ methods:
 
 
     The blob need not already exist.'
-  signature: 'get_blob_client(container: Union[ContainerProperties, str], blob: Union[BlobProperties,
-    str], snapshot: Optional[Union[Dict[str, Any], str]] = None) -> BlobClient'
+  signature: 'get_blob_client(container: ContainerProperties | str, blob: BlobProperties
+    | str, snapshot: Dict[str, Any] | str | None = None) -> BlobClient'
   parameters:
   - name: container
     description: 'The container that the blob is in. This can either be the name of
@@ -440,8 +440,7 @@ methods:
 
 
     The container need not already exist.'
-  signature: 'get_container_client(container: Union[ContainerProperties, str]) ->
-    ContainerClient'
+  signature: 'get_container_client(container: ContainerProperties | str) -> ContainerClient'
   parameters:
   - name: container
     description: 'The container. This can either be the name of the container,
@@ -577,8 +576,8 @@ methods:
     The generator will lazily follow the continuation tokens returned by
 
     the service and stop when all containers have been returned.'
-  signature: 'list_containers(name_starts_with: Optional[str] = None, include_metadata:
-    Optional[bool] = False, **kwargs) -> ItemPaged[ContainerProperties]'
+  signature: 'list_containers(name_starts_with: str | None = None, include_metadata:
+    bool | None = False, **kwargs) -> ItemPaged[ContainerProperties]'
   parameters:
   - name: name_starts_with
     description: 'Filters the results to return only containers whose names
@@ -645,11 +644,11 @@ methods:
     If an element (e.g. analytics_logging) is left as None, the
 
     existing settings on the service for that functionality are preserved.'
-  signature: 'set_service_properties(analytics_logging: Optional[BlobAnalyticsLogging]
-    = None, hour_metrics: Optional[Metrics] = None, minute_metrics: Optional[Metrics]
-    = None, cors: Optional[List[CorsRule]] = None, target_version: Optional[str] =
-    None, delete_retention_policy: Optional[RetentionPolicy] = None, static_website:
-    Optional[StaticWebsite] = None, **kwargs) -> None'
+  signature: 'set_service_properties(analytics_logging: BlobAnalyticsLogging | None
+    = None, hour_metrics: Metrics | None = None, minute_metrics: Metrics | None =
+    None, cors: List[CorsRule] | None = None, target_version: str | None = None, delete_retention_policy:
+    RetentionPolicy | None = None, static_website: StaticWebsite | None = None, **kwargs)
+    -> None'
   parameters:
   - name: analytics_logging
     description: Groups the Azure Analytics Logging settings.
@@ -737,7 +736,7 @@ methods:
 
     New in version 12.4.0: This operation was introduced in API version ''2019-12-12''.'
   signature: 'undelete_container(deleted_container_name: str, deleted_container_version:
-    str, **kwargs: Any) -> azure.storage.blob._container_client.ContainerClient'
+    str, **kwargs: Any) -> ContainerClient'
   parameters:
   - name: deleted_container_name
     description: Specifies the name of the deleted container to restore.

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobType.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlobType.yml
@@ -2,10 +2,10 @@
 uid: azure.storage.blob.BlobType
 name: BlobType
 fullName: azure.storage.blob.BlobType
-summary: An enumeration.
 module: azure.storage.blob
 constructor:
-  syntax: BlobType(value)
+  syntax: BlobType(value, names=None, *, module=None, qualname=None, type=None, start=1,
+    boundary=None)
 inheritances:
 - builtins.str
 - enum.Enum

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlockState.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.BlockState.yml
@@ -5,7 +5,8 @@ fullName: azure.storage.blob.BlockState
 summary: Block blob block types.
 module: azure.storage.blob
 constructor:
-  syntax: BlockState(value)
+  syntax: BlockState(value, names=None, *, module=None, qualname=None, type=None,
+    start=1, boundary=None)
 inheritances:
 - builtins.str
 - enum.Enum

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.ContainerClient.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.ContainerClient.yml
@@ -145,8 +145,8 @@ methods:
     the Blob service creates a lease on the container and returns a new
 
     lease ID.'
-  signature: 'acquire_lease(lease_duration: int = - 1, lease_id: Optional[str] = None,
-    **kwargs) -> azure.storage.blob._lease.BlobLeaseClient'
+  signature: 'acquire_lease(lease_duration: int = -1, lease_id: str | None = None,
+    **kwargs) -> BlobLeaseClient'
   parameters:
   - name: lease_duration
     description: 'Specifies the duration of the lease, in seconds, or negative one
@@ -230,9 +230,8 @@ methods:
   summary: 'Creates a new container under the specified account. If the container
 
     with the same name already exists, the operation fails.'
-  signature: 'create_container(metadata: Optional[Dict[str, str]] = None, public_access:
-    Optional[Union[PublicAccess, str]] = None, **kwargs: Any) -> Dict[str, Union[str,
-    datetime]]'
+  signature: 'create_container(metadata: Dict[str, str] | None = None, public_access:
+    PublicAccess | str | None = None, **kwargs: Any) -> Dict[str, str | datetime]'
   parameters:
   - name: metadata
     description: 'A dict with name_value pairs to associate with the
@@ -299,8 +298,8 @@ methods:
     specifying *include=["deleted"]*
 
     option. Soft-deleted blob or snapshot can be restored using <xref:azure.storage.blob.BlobClient.undelete>'
-  signature: 'delete_blob(blob: Union[str, azure.storage.blob._models.BlobProperties],
-    delete_snapshots: Optional[str] = None, **kwargs) -> None'
+  signature: 'delete_blob(blob: str | BlobProperties, delete_snapshots: str | None
+    = None, **kwargs) -> None'
   parameters:
   - name: blob
     description: 'The blob with which to interact. If specified, this value will override
@@ -416,8 +415,8 @@ methods:
 
 
     The maximum number of blobs that can be deleted in a single request is 256.'
-  signature: 'delete_blobs(*blobs: Union[str, Dict[str, Any], azure.storage.blob._models.BlobProperties],
-    **kwargs: Any) -> Iterator[azure.core.pipeline.transport._base.HttpResponse]'
+  signature: 'delete_blobs(*blobs: str | Dict[str, Any] | BlobProperties, **kwargs:
+    Any) -> Iterator[HttpResponse]'
   parameters:
   - name: blobs
     description: "The blobs to delete. This can be a single blob, or multiple values\
@@ -582,8 +581,8 @@ methods:
 
     a stream. Using chunks() returns an iterator which allows the user to iterate
     over the content in chunks.'
-  signature: 'download_blob(blob: Union[str, BlobProperties], offset: int = None,
-    length: int = None, *, encoding: str, **kwargs) -> StorageStreamDownloader[str]'
+  signature: 'download_blob(blob: str | BlobProperties, offset: int = None, length:
+    int = None, *, encoding: str, **kwargs) -> StorageStreamDownloader[str]'
   parameters:
   - name: blob
     description: 'The blob with which to interact. If specified, this value will override
@@ -754,8 +753,8 @@ methods:
     The generator will lazily follow the continuation tokens returned by
 
     the service.'
-  signature: 'find_blobs_by_tags(filter_expression: str, **kwargs: Optional[Any])
-    -> azure.core.paging.ItemPaged[azure.storage.blob._models.FilteredBlob]'
+  signature: 'find_blobs_by_tags(filter_expression: str, **kwargs: Any | None) ->
+    ItemPaged[FilteredBlob]'
   parameters:
   - name: filter_expression
     description: 'The expression to find blobs whose tags matches the specified condition.
@@ -892,8 +891,8 @@ methods:
 
 
     The blob need not already exist.'
-  signature: 'get_blob_client(blob: Union[str, azure.storage.blob._models.BlobProperties],
-    snapshot: Optional[str] = None) -> azure.storage.blob._blob_client.BlobClient'
+  signature: 'get_blob_client(blob: str | BlobProperties, snapshot: str = None) ->
+    BlobClient'
   parameters:
   - name: blob
     description: The blob with which to interact.
@@ -957,7 +956,7 @@ methods:
   summary: 'Returns all user-defined metadata and system properties for the specified
 
     container. The data returned does not include the container''s list of blobs.'
-  signature: 'get_container_properties(**kwargs: Any) -> azure.storage.blob._models.ContainerProperties'
+  signature: 'get_container_properties(**kwargs: Any) -> ContainerProperties'
   parameters:
   - name: lease
     description: 'If specified, get_container_properties only succeeds if the
@@ -998,7 +997,7 @@ methods:
     as snapshots,
 
     versions, soft-deleted blobs, etc. To get any of this data, use <xref:azure.storage.blob.ContainerClient.list_blobs>.'
-  signature: 'list_blob_names(**kwargs: Any) -> azure.core.paging.ItemPaged[str]'
+  signature: 'list_blob_names(**kwargs: Any) -> ItemPaged[str]'
   parameters:
   - name: name_starts_with
     description: 'Filters the results to return only blobs whose names
@@ -1021,8 +1020,8 @@ methods:
     The generator will lazily follow the continuation tokens returned by
 
     the service.'
-  signature: 'list_blobs(name_starts_with: Optional[str] = None, include: Optional[Union[str,
-    List[str]]] = None, **kwargs: Any) -> azure.core.paging.ItemPaged[azure.storage.blob._models.BlobProperties]'
+  signature: 'list_blobs(name_starts_with: str | None = None, include: str | List[str]
+    | None = None, **kwargs: Any) -> ItemPaged[BlobProperties]'
   parameters:
   - name: name_starts_with
     description: 'Filters the results to return only blobs whose names
@@ -1064,8 +1063,8 @@ methods:
 
     indicate whether blobs in a container may be accessed publicly.'
   signature: 'set_container_access_policy(signed_identifiers: Dict[str, AccessPolicy],
-    public_access: Optional[Union[str, PublicAccess]] = None, **kwargs) -> Dict[str,
-    Union[str, datetime]]'
+    public_access: str | PublicAccess | None = None, **kwargs) -> Dict[str, str |
+    datetime]'
   parameters:
   - name: signed_identifiers
     description: 'A dictionary of access policies to associate with the container.
@@ -1146,8 +1145,8 @@ methods:
     attached to the container. To remove all metadata from the container,
 
     call this operation with no metadata dict.'
-  signature: 'set_container_metadata(metadata: Optional[Dict[str, str]] = None, **kwargs)
-    -> Dict[str, Union[str, datetime]]'
+  signature: 'set_container_metadata(metadata: Dict[str, str] | None = None, **kwargs)
+    -> Dict[str, str | datetime]'
   parameters:
   - name: metadata
     description: 'A dict containing name-value pairs to associate with the container
@@ -1221,9 +1220,8 @@ methods:
 
 
     The maximum number of blobs that can be updated in a single request is 256.'
-  signature: 'set_premium_page_blob_tier_blobs(premium_page_blob_tier: Optional[Union[str,
-    PremiumPageBlobTier]], *blobs: Union[str, Dict[str, Any], azure.storage.blob._models.BlobProperties],
-    **kwargs: Any) -> Iterator[azure.core.pipeline.transport._base.HttpResponse]'
+  signature: 'set_premium_page_blob_tier_blobs(premium_page_blob_tier: str | PremiumPageBlobTier
+    | None, *blobs: str | Dict[str, Any] | BlobProperties, **kwargs: Any) -> Iterator[HttpResponse]'
   parameters:
   - name: premium_page_blob_tier
     description: 'A page blob tier value to set the blob to. The tier correlates to
@@ -1292,9 +1290,8 @@ methods:
 
 
     The maximum number of blobs that can be updated in a single request is 256.'
-  signature: 'set_standard_blob_tier_blobs(standard_blob_tier: Optional[Union[str,
-    StandardBlobTier]], *blobs: Union[str, Dict[str, Any], azure.storage.blob._models.BlobProperties],
-    **kwargs: Any) -> Iterator[azure.core.pipeline.transport._base.HttpResponse]'
+  signature: 'set_standard_blob_tier_blobs(standard_blob_tier: str | StandardBlobTier
+    | None, *blobs: str | Dict[str, Any] | BlobProperties, **kwargs: Any) -> Iterator[HttpResponse]'
   parameters:
   - name: standard_blob_tier
     description: 'Indicates the tier to be set on all blobs. Options include ''Hot'',
@@ -1377,10 +1374,9 @@ methods:
 - uid: azure.storage.blob.ContainerClient.upload_blob
   name: upload_blob
   summary: Creates a new blob from a data source with automatic chunking.
-  signature: 'upload_blob(name: Union[str, azure.storage.blob._models.BlobProperties],
-    data: Union[Iterable, IO], blob_type: Union[str, azure.storage.blob._models.BlobType]
-    = <BlobType.BLOCKBLOB: ''BlockBlob''>, length: Optional[int] = None, metadata:
-    Optional[Dict[str, str]] = None, **kwargs) -> azure.storage.blob._blob_client.BlobClient'
+  signature: 'upload_blob(name: str | BlobProperties, data: Iterable | IO, blob_type:
+    str | BlobType = BlobType.BLOCKBLOB, length: int | None = None, metadata: Dict[str,
+    str] | None = None, **kwargs) -> BlobClient'
   parameters:
   - name: name
     description: 'The blob with which to interact. If specified, this value will override
@@ -1615,8 +1611,8 @@ methods:
     the service. This operation will list blobs in accordance with a hierarchy,
 
     as delimited by the specified delimiter character.'
-  signature: 'walk_blobs(name_starts_with: Optional[str] = None, include: Optional[Any]
-    = None, delimiter: str = ''/'', **kwargs: Optional[Any]) -> azure.core.paging.ItemPaged[azure.storage.blob._models.BlobProperties]'
+  signature: 'walk_blobs(name_starts_with: str | None = None, include: Any | None
+    = None, delimiter: str = ''/'', **kwargs: Any | None) -> ItemPaged[BlobProperties]'
   parameters:
   - name: name_starts_with
     description: 'Filters the results to return only blobs whose names

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.ExponentialRetry.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.ExponentialRetry.yml
@@ -125,5 +125,5 @@ attributes:
 - uid: azure.storage.blob.ExponentialRetry.next
   name: next
   summary: Pointer to the next policy or a transport. Will be set at pipeline creation.
-  signature: 'next: Union[HTTPPolicy[HTTPRequestTypeVar, HTTPResponseTypeVar], HttpTransport[HTTPRequestTypeVar,
-    HTTPResponseTypeVar]]'
+  signature: 'next: ''HTTPPolicy[HTTPRequestTypeVar, HTTPResponseTypeVar]'' | ''HttpTransport[HTTPRequestTypeVar,
+    HTTPResponseTypeVar]'''

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.ImmutabilityPolicy.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.ImmutabilityPolicy.yml
@@ -18,7 +18,7 @@ constructor:
       to expire.
     types:
     - <xref:datetime.datetime>
-  - name: or ~azure.storage.blob.BlobImmutabilityPolicyMode policy_mode
+  - name: policy_mode
     description: 'Specifies the immutability policy mode to set on the blob.
 
       Possible values to set include: "Locked", "Unlocked".
@@ -26,6 +26,7 @@ constructor:
       "Mutable" can only be returned by service, don''t set to "Mutable".'
     types:
     - <xref:str>
+    - <xref:azure.storage.blob.BlobImmutabilityPolicyMode>
 methods:
 - uid: azure.storage.blob.ImmutabilityPolicy.get
   name: get

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.LinearRetry.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.LinearRetry.yml
@@ -113,5 +113,5 @@ attributes:
 - uid: azure.storage.blob.LinearRetry.next
   name: next
   summary: Pointer to the next policy or a transport. Will be set at pipeline creation.
-  signature: 'next: Union[HTTPPolicy[HTTPRequestTypeVar, HTTPResponseTypeVar], HttpTransport[HTTPRequestTypeVar,
-    HTTPResponseTypeVar]]'
+  signature: 'next: ''HTTPPolicy[HTTPRequestTypeVar, HTTPResponseTypeVar]'' | ''HttpTransport[HTTPRequestTypeVar,
+    HTTPResponseTypeVar]'''

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.PartialBatchErrorException.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.PartialBatchErrorException.yml
@@ -23,6 +23,10 @@ constructor:
     types:
     - <xref:list>
 methods:
+- uid: azure.storage.blob.PartialBatchErrorException.add_note
+  name: add_note
+  summary: "Exception.add_note(note) \u2013\nadd a note to the exception"
+  signature: add_note()
 - uid: azure.storage.blob.PartialBatchErrorException.raise_with_traceback
   name: raise_with_traceback
   signature: raise_with_traceback()

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.PremiumPageBlobTier.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.PremiumPageBlobTier.yml
@@ -12,7 +12,8 @@ summary: 'Specifies the page blob tier to set the blob to. This is only applicab
   for detailed information on the corresponding IOPS and throughput per PageBlobTier.'
 module: azure.storage.blob
 constructor:
-  syntax: PremiumPageBlobTier(value)
+  syntax: PremiumPageBlobTier(value, names=None, *, module=None, qualname=None, type=None,
+    start=1, boundary=None)
 inheritances:
 - builtins.str
 - enum.Enum

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.PublicAccess.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.PublicAccess.yml
@@ -6,7 +6,8 @@ summary: Specifies whether data in the container may be accessed publicly and th
   level of access.
 module: azure.storage.blob
 constructor:
-  syntax: PublicAccess(value)
+  syntax: PublicAccess(value, names=None, *, module=None, qualname=None, type=None,
+    start=1, boundary=None)
 inheritances:
 - builtins.str
 - enum.Enum

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.QuickQueryDialect.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.QuickQueryDialect.yml
@@ -5,7 +5,8 @@ fullName: azure.storage.blob.QuickQueryDialect
 summary: Specifies the quick query input/output dialect.
 module: azure.storage.blob
 constructor:
-  syntax: QuickQueryDialect(value)
+  syntax: QuickQueryDialect(value, names=None, *, module=None, qualname=None, type=None,
+    start=1, boundary=None)
 inheritances:
 - builtins.str
 - enum.Enum

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.RehydratePriority.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.RehydratePriority.yml
@@ -8,7 +8,8 @@ summary: 'If an object is in rehydrate pending state then this header is returne
   rehydrate. Valid values are High and Standard.'
 module: azure.storage.blob
 constructor:
-  syntax: RehydratePriority(value)
+  syntax: RehydratePriority(value, names=None, *, module=None, qualname=None, type=None,
+    start=1, boundary=None)
 inheritances:
 - builtins.str
 - enum.Enum

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.SequenceNumberAction.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.SequenceNumberAction.yml
@@ -5,7 +5,8 @@ fullName: azure.storage.blob.SequenceNumberAction
 summary: Sequence number actions.
 module: azure.storage.blob
 constructor:
-  syntax: SequenceNumberAction(value)
+  syntax: SequenceNumberAction(value, names=None, *, module=None, qualname=None, type=None,
+    start=1, boundary=None)
 inheritances:
 - builtins.str
 - enum.Enum

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.StandardBlobTier.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.StandardBlobTier.yml
@@ -7,7 +7,8 @@ summary: 'Specifies the blob tier to set the blob to. This is only applicable fo
   block blobs on standard storage accounts.'
 module: azure.storage.blob
 constructor:
-  syntax: StandardBlobTier(value)
+  syntax: StandardBlobTier(value, names=None, *, module=None, qualname=None, type=None,
+    start=1, boundary=None)
 inheritances:
 - builtins.str
 - enum.Enum

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.StorageErrorCode.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.StorageErrorCode.yml
@@ -2,10 +2,10 @@
 uid: azure.storage.blob.StorageErrorCode
 name: StorageErrorCode
 fullName: azure.storage.blob.StorageErrorCode
-summary: An enumeration.
 module: azure.storage.blob
 constructor:
-  syntax: StorageErrorCode(value)
+  syntax: StorageErrorCode(value, names=None, *, module=None, qualname=None, type=None,
+    start=1, boundary=None)
 inheritances:
 - builtins.str
 - enum.Enum

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.StorageStreamDownloader.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.StorageStreamDownloader.yml
@@ -137,7 +137,7 @@ methods:
   summary: 'Read up to size bytes from the stream and return them. If size
 
     is unspecified or is -1, all bytes will be read.'
-  signature: 'read(size: Optional[int] = - 1) -> T'
+  signature: 'read(size: int | None = -1) -> T'
   parameters:
   - name: size
     description: 'The number of bytes to download from the stream. Leave unsepcified

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.BlobClient.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.BlobClient.yml
@@ -150,8 +150,8 @@ methods:
     This will leave a destination blob with zero length and full metadata.
 
     This will raise an error if the copy operation has already ended.'
-  signature: 'async abort_copy(copy_id: Union[str, Dict[str, Any], azure.storage.blob._models.BlobProperties],
-    **kwargs: Any) -> None'
+  signature: 'async abort_copy(copy_id: str | Dict[str, Any] | BlobProperties, **kwargs:
+    Any) -> None'
   parameters:
   - name: copy_id
     description: 'The copy operation to abort. This can be either an ID, or an
@@ -183,8 +183,8 @@ methods:
     If the blob does not have an active lease, the Blob
 
     Service creates a lease on the blob and returns a new lease.'
-  signature: 'async acquire_lease(lease_duration: int = - 1, lease_id: Optional[str]
-    = None, **kwargs: Any) -> azure.storage.blob.aio._lease_async.BlobLeaseClient'
+  signature: 'async acquire_lease(lease_duration: int = -1, lease_id: str | None =
+    None, **kwargs: Any) -> BlobLeaseClient'
   parameters:
   - name: lease_duration
     description: 'Specifies the duration of the lease, in seconds, or negative one
@@ -273,8 +273,8 @@ methods:
 - uid: azure.storage.blob.aio.BlobClient.append_block
   name: append_block
   summary: Commits a new block of data to the end of the existing append blob.
-  signature: 'async append_block(data: Union[bytes, str, Iterable[AnyStr], IO[AnyStr]],
-    length: Optional[int] = None, **kwargs) -> Dict[str, Union[str, datetime, int]]'
+  signature: 'async append_block(data: bytes | str | Iterable[AnyStr] | IO[AnyStr],
+    length: int | None = None, **kwargs) -> Dict[str, str | datetime | int]'
   parameters:
   - name: data
     description: Content of the block.
@@ -419,9 +419,9 @@ methods:
   name: append_block_from_url
   summary: Creates a new block to be committed as part of a blob, where the contents
     are read from a source url.
-  signature: 'async append_block_from_url(copy_source_url: str, source_offset: Optional[int]
-    = None, source_length: Optional[int] = None, **kwargs) -> Dict[str, Union[str,
-    datetime, int]]'
+  signature: 'async append_block_from_url(copy_source_url: str, source_offset: int
+    | None = None, source_length: int | None = None, **kwargs) -> Dict[str, str |
+    datetime | int]'
   parameters:
   - name: copy_source_url
     description: 'The URL of the source data. It can point to any Azure Blob or File,
@@ -604,7 +604,7 @@ methods:
   name: clear_page
   summary: Clears a range of pages.
   signature: 'async clear_page(offset: int, length: int, **kwargs: Any) -> Dict[str,
-    Union[str, datetime]]'
+    str | datetime]'
   parameters:
   - name: offset
     description: 'Start of byte range to use for writing to a section of the blob.
@@ -729,8 +729,8 @@ methods:
 
     block IDs that make up the blob.'
   signature: 'async commit_block_list(block_list: List[BlobBlock], content_settings:
-    Optional[ContentSettings] = None, metadata: Optional[Dict[str, str]] = None, **kwargs)
-    -> Dict[str, Union[str, datetime]]'
+    ContentSettings | None = None, metadata: Dict[str, str] | None = None, **kwargs)
+    -> Dict[str, str | datetime]'
   parameters:
   - name: block_list
     description: List of Blockblobs.
@@ -895,9 +895,9 @@ methods:
 - uid: azure.storage.blob.aio.BlobClient.create_append_blob
   name: create_append_blob
   summary: Creates a new Append Blob.
-  signature: 'async create_append_blob(content_settings: Optional[ContentSettings]
-    = None, metadata: Optional[Dict[str, str]] = None, **kwargs: Any) -> Dict[str,
-    Union[str, datetime]]'
+  signature: 'async create_append_blob(content_settings: ContentSettings | None =
+    None, metadata: Dict[str, str] | None = None, **kwargs: Any) -> Dict[str, str
+    | datetime]'
   parameters:
   - name: content_settings
     description: 'ContentSettings object used to set blob properties. Used to set
@@ -1026,9 +1026,9 @@ methods:
 - uid: azure.storage.blob.aio.BlobClient.create_page_blob
   name: create_page_blob
   summary: Creates a new Page Blob of the specified size.
-  signature: 'async create_page_blob(size: int, content_settings: Optional[ContentSettings]
-    = None, metadata: Optional[Dict[str, str]] = None, premium_page_blob_tier: Optional[Union[str,
-    PremiumPageBlobTier]] = None, **kwargs) -> Dict[str, Union[str, datetime]]'
+  signature: 'async create_page_blob(size: int, content_settings: ContentSettings
+    | None = None, metadata: Dict[str, str] | None = None, premium_page_blob_tier:
+    str | PremiumPageBlobTier | None = None, **kwargs) -> Dict[str, str | datetime]'
   parameters:
   - name: size
     description: 'This specifies the maximum size for the page blob, up to 1 TB.
@@ -1197,8 +1197,8 @@ methods:
     is taken, with a DateTime value appended to indicate the time at which the
 
     snapshot was taken.'
-  signature: 'async create_snapshot(metadata: Optional[Dict[str, str]] = None, **kwargs:
-    Any) -> Dict[str, Union[str, datetime]]'
+  signature: 'async create_snapshot(metadata: Dict[str, str] | None = None, **kwargs:
+    Any) -> Dict[str, str | datetime]'
   parameters:
   - name: metadata
     description: Name-value pairs associated with the blob as metadata.
@@ -1752,8 +1752,7 @@ methods:
     blob.
 
     The keys in the returned dictionary include ''sku_name'' and ''account_kind''.'
-  signature: 'async get_account_information(**kwargs: Optional[int]) -> Dict[str,
-    str]'
+  signature: 'async get_account_information(**kwargs: int | None) -> Dict[str, str]'
   return:
     description: A dict of account information (SKU and account type).
     types:
@@ -1763,7 +1762,7 @@ methods:
   summary: 'Returns all user-defined metadata, standard HTTP properties, and
 
     system properties for the blob. It does not return the content of the blob.'
-  signature: 'async get_blob_properties(**kwargs: Any) -> azure.storage.blob._models.BlobProperties'
+  signature: 'async get_blob_properties(**kwargs: Any) -> BlobProperties'
   parameters:
   - name: lease
     description: 'Required if the blob has an active lease. Value can be a BlobLeaseClient
@@ -1899,8 +1898,8 @@ methods:
   summary: 'The Get Block List operation retrieves the list of blocks that have
 
     been uploaded as part of a block blob.'
-  signature: 'async get_block_list(block_list_type: Optional[str] = ''committed'',
-    **kwargs: Any) -> Tuple[List[azure.storage.blob._models.BlobBlock], List[azure.storage.blob._models.BlobBlock]]'
+  signature: 'async get_block_list(block_list_type: str | None = ''committed'', **kwargs:
+    Any) -> Tuple[List[BlobBlock], List[BlobBlock]]'
   parameters:
   - name: block_list_type
     description: 'Specifies whether to return the list of committed
@@ -1951,7 +1950,7 @@ methods:
 
     New in version 12.2.0: This operation was introduced in API version ''2019-07-07''.'
   signature: 'async get_page_range_diff_for_managed_disk(previous_snapshot_url: str,
-    offset: Optional[int] = None, length: Optional[int] = None, **kwargs) -> Tuple[List[Dict[str,
+    offset: int | None = None, length: int | None = None, **kwargs) -> Tuple[List[Dict[str,
     int]], List[Dict[str, int]]]'
   parameters:
   - name: previous_snapshot_url
@@ -2052,8 +2051,8 @@ methods:
   summary: 'DEPRECATED: Returns the list of valid page ranges for a Page Blob or snapshot
 
     of a page blob.'
-  signature: 'async get_page_ranges(offset: Optional[int] = None, length: Optional[int]
-    = None, previous_snapshot_diff: Optional[Union[str, Dict[str, Any]]] = None, **kwargs)
+  signature: 'async get_page_ranges(offset: int | None = None, length: int | None
+    = None, previous_snapshot_diff: str | Dict[str, Any] | None = None, **kwargs)
     -> Tuple[List[Dict[str, int]], List[Dict[str, int]]]'
   parameters:
   - name: offset
@@ -2168,9 +2167,9 @@ methods:
     of a page blob. If *previous_snapshot* is specified, the result will be
 
     a diff of changes between the target blob and the previous snapshot.'
-  signature: 'list_page_ranges(*, offset: Optional[int] = None, length: Optional[int]
-    = None, previous_snapshot: Optional[Union[str, Dict[str, Any]]] = None, **kwargs:
-    Any) -> azure.core.async_paging.AsyncItemPaged[azure.storage.blob._models.PageRange]'
+  signature: 'list_page_ranges(*, offset: int | None = None, length: int | None =
+    None, previous_snapshot: str | Dict[str, Any] | None = None, **kwargs: Any) ->
+    AsyncItemPaged[PageRange]'
   parameters:
   - name: offset
     description: 'Start of byte range to use for getting valid page ranges.
@@ -2286,7 +2285,7 @@ methods:
 
     This operations returns a BlobQueryReader, users need to use readall() or readinto()
     to get query data.'
-  signature: 'query_blob(query_expression: str, **kwargs: Any) -> azure.storage.blob._quick_query_helper.BlobQueryReader'
+  signature: 'query_blob(query_expression: str, **kwargs: Any) -> BlobQueryReader'
   parameters:
   - name: query_expression
     description: Required. a query statement.
@@ -2429,8 +2428,7 @@ methods:
     If the specified value is less than the current size of the blob,
 
     then all pages above the specified value are cleared.'
-  signature: 'async resize_blob(size: int, **kwargs: Any) -> Dict[str, Union[str,
-    datetime]]'
+  signature: 'async resize_blob(size: int, **kwargs: Any) -> Dict[str, str | datetime]'
   parameters:
   - name: size
     description: 'Size used to resize blob. Maximum size for a page blob is up to
@@ -2514,7 +2512,7 @@ methods:
   name: seal_append_blob
   summary: "The Seal operation seals the Append Blob to make it read-only.\n\n   New\
     \ in version 12.4.0."
-  signature: async seal_append_blob(**kwargs) -> Dict[str, Union[str, datetime, int]]
+  signature: async seal_append_blob(**kwargs) -> Dict[str, str | datetime | int]
   parameters:
   - name: appendpos_condition
     description: 'Optional conditional header, used only for the Append Block operation.
@@ -2583,8 +2581,8 @@ methods:
 - uid: azure.storage.blob.aio.BlobClient.set_blob_metadata
   name: set_blob_metadata
   summary: Sets user-defined metadata for the blob as one or more name-value pairs.
-  signature: 'async set_blob_metadata(metadata: Optional[Dict[str, str]] = None, **kwargs:
-    Any) -> Dict[str, Union[str, datetime]]'
+  signature: 'async set_blob_metadata(metadata: Dict[str, str] | None = None, **kwargs:
+    Any) -> Dict[str, str | datetime]'
   parameters:
   - name: metadata
     description: 'Dict containing name and value pairs. Each call to this operation
@@ -2688,8 +2686,8 @@ methods:
     \ existing tags attached to the blob. To remove all\n   tags from the blob, call\
     \ this operation with no tags set.\n\nNew in version 12.4.0: This operation was\
     \ introduced in API version '2019-12-12'."
-  signature: 'async set_blob_tags(tags: Optional[Dict[str, str]] = None, **kwargs:
-    Any) -> Dict[str, Any]'
+  signature: 'async set_blob_tags(tags: Dict[str, str] | None = None, **kwargs: Any)
+    -> Dict[str, Any]'
   parameters:
   - name: tags
     description: 'Name-value pairs associated with the blob as tag. Tags are case-sensitive.
@@ -2756,8 +2754,8 @@ methods:
 
 
     If one property is set for the content_settings, all properties will be overridden.'
-  signature: 'async set_http_headers(content_settings: Optional[ContentSettings] =
-    None, **kwargs: Any) -> None'
+  signature: 'async set_http_headers(content_settings: ContentSettings | None = None,
+    **kwargs: Any) -> None'
   parameters:
   - name: content_settings
     description: 'ContentSettings object used to set blob properties. Used to set
@@ -2861,8 +2859,8 @@ methods:
 
 
     New in version 12.10.0: This operation was introduced in API version ''2020-10-02''.'
-  signature: 'async set_legal_hold(legal_hold: bool, **kwargs: Any) -> Dict[str, Union[str,
-    datetime, bool]]'
+  signature: 'async set_legal_hold(legal_hold: bool, **kwargs: Any) -> Dict[str, str
+    | datetime | bool]'
   parameters:
   - name: legal_hold
     description: Specified if a legal hold should be set on the blob.
@@ -2881,8 +2879,8 @@ methods:
   name: set_premium_page_blob_tier
   summary: Sets the page blob tiers on the blob. This API is only supported for page
     blobs on premium accounts.
-  signature: 'async set_premium_page_blob_tier(premium_page_blob_tier: Union[str,
-    PremiumPageBlobTier], **kwargs: Any) -> None'
+  signature: 'async set_premium_page_blob_tier(premium_page_blob_tier: str | PremiumPageBlobTier,
+    **kwargs: Any) -> None'
   parameters:
   - name: premium_page_blob_tier
     description: 'A page blob tier value to set the blob to. The tier correlates to
@@ -2926,8 +2924,8 @@ methods:
 - uid: azure.storage.blob.aio.BlobClient.set_sequence_number
   name: set_sequence_number
   summary: Sets the blob sequence number.
-  signature: 'async set_sequence_number(sequence_number_action: Union[str, SequenceNumberAction],
-    sequence_number: Optional[str] = None, **kwargs) -> Dict[str, Union[str, datetime]]'
+  signature: 'async set_sequence_number(sequence_number_action: str | SequenceNumberAction,
+    sequence_number: str | None = None, **kwargs) -> Dict[str, str | datetime]'
   parameters:
   - name: sequence_number_action
     description: 'This property indicates how the service should modify the blob''s
@@ -3016,7 +3014,7 @@ methods:
     A block blob''s tier determines Hot/Cool/Archive storage type.
 
     This operation does not update the blob''s ETag.'
-  signature: 'async set_standard_blob_tier(standard_blob_tier: Union[str, StandardBlobTier],
+  signature: 'async set_standard_blob_tier(standard_blob_tier: str | StandardBlobTier,
     **kwargs: Any) -> None'
   parameters:
   - name: standard_blob_tier
@@ -3068,8 +3066,8 @@ methods:
 - uid: azure.storage.blob.aio.BlobClient.stage_block
   name: stage_block
   summary: Creates a new block to be committed as part of a blob.
-  signature: 'async stage_block(block_id: str, data: Union[Iterable, IO], length:
-    Optional[int] = None, **kwargs) -> None'
+  signature: 'async stage_block(block_id: str, data: Iterable | IO, length: int |
+    None = None, **kwargs) -> None'
   parameters:
   - name: block_id
     description: 'A string value that identifies the block.
@@ -3158,9 +3156,9 @@ methods:
   summary: 'Creates a new block to be committed as part of a blob where
 
     the contents are read from a URL.'
-  signature: 'async stage_block_from_url(block_id: Union[str, int], source_url: str,
-    source_offset: Optional[int] = None, source_length: Optional[int] = None, source_content_md5:
-    Optional[Union[bytes, bytearray]] = None, **kwargs) -> None'
+  signature: 'async stage_block_from_url(block_id: str | int, source_url: str, source_offset:
+    int | None = None, source_length: int | None = None, source_content_md5: bytes
+    | bytearray | None = None, **kwargs) -> None'
   parameters:
   - name: block_id
     description: 'A string value that identifies the block.
@@ -3300,9 +3298,9 @@ methods:
     end of the copy operation, the destination blob will have the same committed
 
     block count as the source.'
-  signature: 'async start_copy_from_url(source_url: str, metadata: Optional[Dict[str,
-    str]] = None, incremental_copy: bool = False, **kwargs: Any) -> Dict[str, Union[str,
-    datetime]]'
+  signature: 'async start_copy_from_url(source_url: str, metadata: Dict[str, str]
+    | None = None, incremental_copy: bool = False, **kwargs: Any) -> Dict[str, str
+    | datetime]'
   parameters:
   - name: source_url
     description: 'A URL of up to 2 KB in length that specifies a file or blob.
@@ -3611,10 +3609,9 @@ methods:
 - uid: azure.storage.blob.aio.BlobClient.upload_blob
   name: upload_blob
   summary: Creates a new blob from a data source with automatic chunking.
-  signature: 'async upload_blob(data: Union[bytes, str, Iterable, IO], blob_type:
-    Union[str, azure.storage.blob._models.BlobType] = <BlobType.BLOCKBLOB: ''BlockBlob''>,
-    length: Optional[int] = None, metadata: Optional[Dict[str, str]] = None, **kwargs)
-    -> Any'
+  signature: 'async upload_blob(data: bytes | str | Iterable | IO, blob_type: str
+    | BlobType = BlobType.BLOCKBLOB, length: int | None = None, metadata: Dict[str,
+    str] | None = None, **kwargs) -> Any'
   parameters:
   - name: data
     description: The blob data to upload.
@@ -4064,7 +4061,7 @@ methods:
   name: upload_page
   summary: The Upload Pages operation writes a range of pages to a page blob.
   signature: 'async upload_page(page: bytes, offset: int, length: int, **kwargs) ->
-    Dict[str, Union[str, datetime]]'
+    Dict[str, str | datetime]'
   parameters:
   - name: page
     description: Content of the page.

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.BlobLeaseClient.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.BlobLeaseClient.yml
@@ -10,7 +10,7 @@ summary: 'Creates a new BlobLeaseClient.
 
   This client provides lease operations on a BlobClient or ContainerClient.'
 constructor:
-  syntax: 'BlobLeaseClient(client: Union[BlobClient, ContainerClient], lease_id: Optional[str]
+  syntax: 'BlobLeaseClient(client: BlobClient | ContainerClient, lease_id: str | None
     = None)'
   parameters:
   - name: client
@@ -57,7 +57,7 @@ methods:
     If the container does not have an active lease, the Blob service creates a
 
     lease on the container and returns a new lease ID.'
-  signature: 'async acquire(lease_duration: int = - 1, **kwargs: Any) -> None'
+  signature: 'async acquire(lease_duration: int = -1, **kwargs: Any) -> None'
   parameters:
   - name: lease_duration
     description: 'Specifies the duration of the lease, in seconds, or negative one
@@ -140,8 +140,8 @@ methods:
     When a lease is successfully broken, the response indicates the interval
 
     in seconds until a new lease can be acquired.'
-  signature: 'async break_lease(lease_break_period: Optional[int] = None, **kwargs:
-    Any) -> int'
+  signature: 'async break_lease(lease_break_period: int | None = None, **kwargs: Any)
+    -> int'
   parameters:
   - name: lease_break_period
     description: 'This is the proposed duration of seconds that the lease

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.BlobPrefix.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.BlobPrefix.yml
@@ -104,7 +104,7 @@ methods:
   name: by_page
   summary: Get an async iterator of pages of objects, instead of an async iterator
     of objects.
-  signature: 'by_page(continuation_token: Optional[str] = None) -> AsyncIterator[AsyncIterator[ReturnType]]'
+  signature: 'by_page(continuation_token: str | None = None) -> AsyncIterator[AsyncIterator[ReturnType]]'
   parameters:
   - name: continuation_token
     description: 'An opaque continuation token. This value can be retrieved from the

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.BlobServiceClient.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.BlobServiceClient.yml
@@ -151,9 +151,8 @@ methods:
     be raised. This method returns a client with which to interact with the newly
 
     created container.'
-  signature: 'async create_container(name: str, metadata: Optional[Dict[str, str]]
-    = None, public_access: Optional[Union[PublicAccess, str]] = None, **kwargs) ->
-    ContainerClient'
+  signature: 'async create_container(name: str, metadata: Dict[str, str] | None =
+    None, public_access: PublicAccess | str | None = None, **kwargs) -> ContainerClient'
   parameters:
   - name: name
     description: The name of the container to create.
@@ -211,8 +210,8 @@ methods:
     collection.
 
     If the container is not found, a ResourceNotFoundError will be raised.'
-  signature: 'async delete_container(container: Union[ContainerProperties, str], lease:
-    Optional[Union[BlobLeaseClient, str]] = None, **kwargs) -> None'
+  signature: 'async delete_container(container: ContainerProperties | str, lease:
+    BlobLeaseClient | str | None = None, **kwargs) -> None'
   parameters:
   - name: container
     description: 'The container to delete. This can either be the name of the container,
@@ -388,8 +387,8 @@ methods:
 
 
     The blob need not already exist.'
-  signature: 'get_blob_client(container: Union[ContainerProperties, str], blob: Union[BlobProperties,
-    str], snapshot: Optional[Union[Dict[str, Any], str]] = None) -> BlobClient'
+  signature: 'get_blob_client(container: ContainerProperties | str, blob: BlobProperties
+    | str, snapshot: Dict[str, Any] | str | None = None) -> BlobClient'
   parameters:
   - name: container
     description: 'The container that the blob is in. This can either be the name of
@@ -440,8 +439,7 @@ methods:
 
 
     The container need not already exist.'
-  signature: 'get_container_client(container: Union[azure.storage.blob._models.ContainerProperties,
-    str]) -> azure.storage.blob.aio._container_client_async.ContainerClient'
+  signature: 'get_container_client(container: ContainerProperties | str) -> ContainerClient'
   parameters:
   - name: container
     description: 'The container. This can either be the name of the container,
@@ -579,8 +577,8 @@ methods:
     The generator will lazily follow the continuation tokens returned by
 
     the service and stop when all containers have been returned.'
-  signature: 'list_containers(name_starts_with: Optional[str] = None, include_metadata:
-    Optional[bool] = False, **kwargs) -> azure.core.async_paging.AsyncItemPaged[azure.storage.blob._models.ContainerProperties]'
+  signature: 'list_containers(name_starts_with: str | None = None, include_metadata:
+    bool | None = False, **kwargs) -> AsyncItemPaged[ContainerProperties]'
   parameters:
   - name: name_starts_with
     description: 'Filters the results to return only containers whose names
@@ -649,11 +647,11 @@ methods:
     If an element (e.g. analytics_logging) is left as None, the
 
     existing settings on the service for that functionality are preserved.'
-  signature: 'async set_service_properties(analytics_logging: Optional[BlobAnalyticsLogging]
-    = None, hour_metrics: Optional[Metrics] = None, minute_metrics: Optional[Metrics]
-    = None, cors: Optional[List[CorsRule]] = None, target_version: Optional[str] =
-    None, delete_retention_policy: Optional[RetentionPolicy] = None, static_website:
-    Optional[StaticWebsite] = None, **kwargs) -> None'
+  signature: 'async set_service_properties(analytics_logging: BlobAnalyticsLogging
+    | None = None, hour_metrics: Metrics | None = None, minute_metrics: Metrics |
+    None = None, cors: List[CorsRule] | None = None, target_version: str | None =
+    None, delete_retention_policy: RetentionPolicy | None = None, static_website:
+    StaticWebsite | None = None, **kwargs) -> None'
   parameters:
   - name: analytics_logging
     description: Groups the Azure Analytics Logging settings.
@@ -741,7 +739,7 @@ methods:
 
     New in version 12.4.0: This operation was introduced in API version ''2019-12-12''.'
   signature: 'async undelete_container(deleted_container_name: str, deleted_container_version:
-    str, **kwargs: Any) -> azure.storage.blob.aio._container_client_async.ContainerClient'
+    str, **kwargs: Any) -> ContainerClient'
   parameters:
   - name: deleted_container_name
     description: Specifies the name of the deleted container to restore.

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.ContainerClient.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.ContainerClient.yml
@@ -142,8 +142,8 @@ methods:
     the Blob service creates a lease on the container and returns a new
 
     lease ID.'
-  signature: 'async acquire_lease(lease_duration: int = - 1, lease_id: Optional[str]
-    = None, **kwargs) -> azure.storage.blob.aio._lease_async.BlobLeaseClient'
+  signature: 'async acquire_lease(lease_duration: int = -1, lease_id: str | None =
+    None, **kwargs) -> BlobLeaseClient'
   parameters:
   - name: lease_duration
     description: 'Specifies the duration of the lease, in seconds, or negative one
@@ -227,9 +227,8 @@ methods:
   summary: 'Creates a new container under the specified account. If the container
 
     with the same name already exists, the operation fails.'
-  signature: 'async create_container(metadata: Optional[Dict[str, str]] = None, public_access:
-    Optional[Union[PublicAccess, str]] = None, **kwargs: Any) -> Dict[str, Union[str,
-    datetime]]'
+  signature: 'async create_container(metadata: Dict[str, str] | None = None, public_access:
+    PublicAccess | str | None = None, **kwargs: Any) -> Dict[str, str | datetime]'
   parameters:
   - name: metadata
     description: 'A dict with name_value pairs to associate with the
@@ -296,8 +295,8 @@ methods:
     specifying *include=["deleted"]*
 
     Soft-deleted blob or snapshot can be restored using <xref:azure.storage.blob.aio.BlobClient.undelete>'
-  signature: 'async delete_blob(blob: Union[str, azure.storage.blob._models.BlobProperties],
-    delete_snapshots: Optional[str] = None, **kwargs) -> None'
+  signature: 'async delete_blob(blob: str | BlobProperties, delete_snapshots: str
+    | None = None, **kwargs) -> None'
   parameters:
   - name: blob
     description: 'The blob with which to interact. If specified, this value will override
@@ -412,8 +411,8 @@ methods:
 
 
     The maximum number of blobs that can be deleted in a single request is 256.'
-  signature: 'async delete_blobs(*blobs: Union[str, Dict[str, Any], azure.storage.blob._models.BlobProperties],
-    **kwargs: Any) -> AsyncIterator[azure.core.pipeline.transport._base_async.AsyncHttpResponse]'
+  signature: 'async delete_blobs(*blobs: str | Dict[str, Any] | BlobProperties, **kwargs:
+    Any) -> AsyncIterator[AsyncHttpResponse]'
   parameters:
   - name: blobs
     description: "The blobs to delete. This can be a single blob, or multiple values\
@@ -580,8 +579,8 @@ methods:
 
     a stream. Using chunks() returns an async iterator which allows the user to iterate
     over the content in chunks.'
-  signature: 'async download_blob(blob: Union[str, BlobProperties], offset: int =
-    None, length: int = None, *, encoding: str, **kwargs) -> StorageStreamDownloader[str]'
+  signature: 'async download_blob(blob: str | BlobProperties, offset: int = None,
+    length: int = None, *, encoding: str, **kwargs) -> StorageStreamDownloader[str]'
   parameters:
   - name: blob
     description: 'The blob with which to interact. If specified, this value will override
@@ -752,8 +751,8 @@ methods:
     The generator will lazily follow the continuation tokens returned by
 
     the service.'
-  signature: 'find_blobs_by_tags(filter_expression: str, **kwargs: Optional[Any])
-    -> azure.core.async_paging.AsyncItemPaged[azure.storage.blob._models.FilteredBlob]'
+  signature: 'find_blobs_by_tags(filter_expression: str, **kwargs: Any | None) ->
+    AsyncItemPaged[FilteredBlob]'
   parameters:
   - name: filter_expression
     description: 'The expression to find blobs whose tags matches the specified condition.
@@ -890,8 +889,8 @@ methods:
 
 
     The blob need not already exist.'
-  signature: 'get_blob_client(blob: Union[azure.storage.blob._models.BlobProperties,
-    str], snapshot: Optional[str] = None) -> azure.storage.blob.aio._blob_client_async.BlobClient'
+  signature: 'get_blob_client(blob: BlobProperties | str, snapshot: str = None) ->
+    BlobClient'
   parameters:
   - name: blob
     description: The blob with which to interact.
@@ -955,7 +954,7 @@ methods:
   summary: 'Returns all user-defined metadata and system properties for the specified
 
     container. The data returned does not include the container''s list of blobs.'
-  signature: 'async get_container_properties(**kwargs: Any) -> azure.storage.blob._models.ContainerProperties'
+  signature: 'async get_container_properties(**kwargs: Any) -> ContainerProperties'
   parameters:
   - name: lease
     description: 'If specified, get_container_properties only succeeds if the
@@ -996,7 +995,7 @@ methods:
     as snapshots,
 
     versions, soft-deleted blobs, etc. To get any of this data, use <xref:azure.storage.blob.aio.ContainerClient.list_blobs>.'
-  signature: 'list_blob_names(**kwargs: Any) -> azure.core.async_paging.AsyncItemPaged[str]'
+  signature: 'list_blob_names(**kwargs: Any) -> AsyncItemPaged[str]'
   parameters:
   - name: name_starts_with
     description: 'Filters the results to return only blobs whose names
@@ -1019,8 +1018,8 @@ methods:
     The generator will lazily follow the continuation tokens returned by
 
     the service.'
-  signature: 'list_blobs(name_starts_with: Optional[str] = None, include: Optional[Union[str,
-    List[str]]] = None, **kwargs: Any) -> azure.core.async_paging.AsyncItemPaged[azure.storage.blob._models.BlobProperties]'
+  signature: 'list_blobs(name_starts_with: str | None = None, include: str | List[str]
+    | None = None, **kwargs: Any) -> AsyncItemPaged[BlobProperties]'
   parameters:
   - name: name_starts_with
     description: 'Filters the results to return only blobs whose names
@@ -1062,8 +1061,8 @@ methods:
 
     indicate whether blobs in a container may be accessed publicly.'
   signature: 'async set_container_access_policy(signed_identifiers: Dict[str, AccessPolicy],
-    public_access: Optional[Union[str, PublicAccess]] = None, **kwargs: Any) -> Dict[str,
-    Union[str, datetime]]'
+    public_access: str | PublicAccess | None = None, **kwargs: Any) -> Dict[str, str
+    | datetime]'
   parameters:
   - name: signed_identifiers
     description: 'A dictionary of access policies to associate with the container.
@@ -1144,8 +1143,8 @@ methods:
     attached to the container. To remove all metadata from the container,
 
     call this operation with no metadata dict.'
-  signature: 'async set_container_metadata(metadata: Optional[Dict[str, str]] = None,
-    **kwargs) -> Dict[str, Union[str, datetime]]'
+  signature: 'async set_container_metadata(metadata: Dict[str, str] | None = None,
+    **kwargs) -> Dict[str, str | datetime]'
   parameters:
   - name: metadata
     description: 'A dict containing name-value pairs to associate with the container
@@ -1197,9 +1196,9 @@ methods:
 
 
     The maximum number of blobs that can be updated in a single request is 256.'
-  signature: 'async set_premium_page_blob_tier_blobs(premium_page_blob_tier: Union[str,
-    PremiumPageBlobTier], *blobs: Union[str, Dict[str, Any], azure.storage.blob._models.BlobProperties],
-    **kwargs: Any) -> AsyncIterator[azure.core.pipeline.transport._base_async.AsyncHttpResponse]'
+  signature: 'async set_premium_page_blob_tier_blobs(premium_page_blob_tier: str |
+    PremiumPageBlobTier, *blobs: str | Dict[str, Any] | BlobProperties, **kwargs:
+    Any) -> AsyncIterator[AsyncHttpResponse]'
   parameters:
   - name: premium_page_blob_tier
     description: 'A page blob tier value to set on all blobs to. The tier correlates
@@ -1270,9 +1269,8 @@ methods:
 
 
     The maximum number of blobs that can be updated in a single request is 256.'
-  signature: 'async set_standard_blob_tier_blobs(standard_blob_tier: Union[str, StandardBlobTier],
-    *blobs: Union[str, Dict[str, Any], azure.storage.blob._models.BlobProperties],
-    **kwargs: Any) -> AsyncIterator[azure.core.pipeline.transport._base_async.AsyncHttpResponse]'
+  signature: 'async set_standard_blob_tier_blobs(standard_blob_tier: str | StandardBlobTier,
+    *blobs: str | Dict[str, Any] | BlobProperties, **kwargs: Any) -> AsyncIterator[AsyncHttpResponse]'
   parameters:
   - name: standard_blob_tier
     description: 'Indicates the tier to be set on all blobs. Options include ''Hot'',
@@ -1355,10 +1353,9 @@ methods:
 - uid: azure.storage.blob.aio.ContainerClient.upload_blob
   name: upload_blob
   summary: Creates a new blob from a data source with automatic chunking.
-  signature: 'async upload_blob(name: Union[str, azure.storage.blob._models.BlobProperties],
-    data: Union[Iterable, IO], blob_type: Union[str, azure.storage.blob._models.BlobType]
-    = <BlobType.BLOCKBLOB: ''BlockBlob''>, length: Optional[int] = None, metadata:
-    Optional[Dict[str, str]] = None, **kwargs) -> azure.storage.blob.aio._blob_client_async.BlobClient'
+  signature: 'async upload_blob(name: str | BlobProperties, data: Iterable | IO, blob_type:
+    str | BlobType = BlobType.BLOCKBLOB, length: int | None = None, metadata: Dict[str,
+    str] | None = None, **kwargs) -> BlobClient'
   parameters:
   - name: name
     description: 'The blob with which to interact. If specified, this value will override
@@ -1593,8 +1590,8 @@ methods:
     the service. This operation will list blobs in accordance with a hierarchy,
 
     as delimited by the specified delimiter character.'
-  signature: 'walk_blobs(name_starts_with: Optional[str] = None, include: Optional[Any]
-    = None, delimiter: str = ''/'', **kwargs: Optional[Any]) -> azure.core.async_paging.AsyncItemPaged[azure.storage.blob._models.BlobProperties]'
+  signature: 'walk_blobs(name_starts_with: str | None = None, include: Any | None
+    = None, delimiter: str = ''/'', **kwargs: Any | None) -> AsyncItemPaged[BlobProperties]'
   parameters:
   - name: name_starts_with
     description: 'Filters the results to return only blobs whose names

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.ExponentialRetry.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.ExponentialRetry.yml
@@ -129,5 +129,5 @@ attributes:
 - uid: azure.storage.blob.aio.ExponentialRetry.next
   name: next
   summary: Pointer to the next policy or a transport. Will be set at pipeline creation.
-  signature: 'next: Union[HTTPPolicy[HTTPRequestTypeVar, HTTPResponseTypeVar], HttpTransport[HTTPRequestTypeVar,
-    HTTPResponseTypeVar]]'
+  signature: 'next: ''HTTPPolicy[HTTPRequestTypeVar, HTTPResponseTypeVar]'' | ''HttpTransport[HTTPRequestTypeVar,
+    HTTPResponseTypeVar]'''

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.LinearRetry.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.LinearRetry.yml
@@ -113,5 +113,5 @@ attributes:
 - uid: azure.storage.blob.aio.LinearRetry.next
   name: next
   summary: Pointer to the next policy or a transport. Will be set at pipeline creation.
-  signature: 'next: Union[HTTPPolicy[HTTPRequestTypeVar, HTTPResponseTypeVar], HttpTransport[HTTPRequestTypeVar,
-    HTTPResponseTypeVar]]'
+  signature: 'next: ''HTTPPolicy[HTTPRequestTypeVar, HTTPResponseTypeVar]'' | ''HttpTransport[HTTPRequestTypeVar,
+    HTTPResponseTypeVar]'''

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.StorageStreamDownloader.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.aio.StorageStreamDownloader.yml
@@ -140,7 +140,7 @@ methods:
   summary: 'Read up to size bytes from the stream and return them. If size
 
     is unspecified or is -1, all bytes will be read.'
-  signature: 'async read(size: Optional[int] = - 1) -> T'
+  signature: 'async read(size: int | None = -1) -> T'
   parameters:
   - name: size
     description: 'The number of bytes to download from the stream. Leave unsepcified

--- a/yml/azure-storage-blob-12.14.1/azure.storage.blob.yml
+++ b/yml/azure-storage-blob-12.14.1/azure.storage.blob.yml
@@ -108,9 +108,9 @@ functions:
 
     ContainerClient or BlobClient.'
   signature: 'generate_account_sas(account_name: str, account_key: str, resource_types:
-    Union[ResourceTypes, str], permission: Union[AccountSasPermissions, str], expiry:
-    Optional[Union[datetime, str]], start: Optional[Union[datetime, str]] = None,
-    ip: Optional[str] = None, **kwargs: Any) -> str'
+    ResourceTypes | str, permission: AccountSasPermissions | str, expiry: datetime
+    | str | None, start: datetime | str | None = None, ip: str | None = None, **kwargs:
+    Any) -> str'
   parameters:
   - name: account_name
     description: The storage account name used to generate the shared access signature.
@@ -224,11 +224,10 @@ functions:
 
     ContainerClient or BlobClient.'
   signature: 'generate_blob_sas(account_name: str, container_name: str, blob_name:
-    str, snapshot: Optional[str] = None, account_key: Optional[str] = None, user_delegation_key:
-    Optional[UserDelegationKey] = None, permission: Optional[Union[BlobSasPermissions,
-    str]] = None, expiry: Optional[Union[datetime, str]] = None, start: Optional[Union[datetime,
-    str]] = None, policy_id: Optional[str] = None, ip: Optional[str] = None, **kwargs:
-    Any) -> Any'
+    str, snapshot: str | None = None, account_key: str | None = None, user_delegation_key:
+    UserDelegationKey | None = None, permission: BlobSasPermissions | str | None =
+    None, expiry: datetime | str | None = None, start: datetime | str | None = None,
+    policy_id: str | None = None, ip: str | None = None, **kwargs: Any) -> Any'
   parameters:
   - name: account_name
     description: The storage account name used to generate the shared access signature.
@@ -402,10 +401,10 @@ functions:
 
     ContainerClient or BlobClient.'
   signature: 'generate_container_sas(account_name: str, container_name: str, account_key:
-    Optional[str] = None, user_delegation_key: Optional[UserDelegationKey] = None,
-    permission: Optional[Union[ContainerSasPermissions, str]] = None, expiry: Optional[Union[datetime,
-    str]] = None, start: Optional[Union[datetime, str]] = None, policy_id: Optional[str]
-    = None, ip: Optional[str] = None, **kwargs: Any) -> Any'
+    str | None = None, user_delegation_key: UserDelegationKey | None = None, permission:
+    ContainerSasPermissions | str | None = None, expiry: datetime | str | None = None,
+    start: datetime | str | None = None, policy_id: str | None = None, ip: str | None
+    = None, **kwargs: Any) -> Any'
   parameters:
   - name: account_name
     description: The storage account name used to generate the shared access signature.


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summarized by Learn Reference PR Assistant

- Updated Python type hinting syntax to the more readable and concise format introduced in Python 3.10. This affects multiple files and instances in the `azure.storage.blob` module. 
- Source code changes in the `azure.storage.blob` module have introduced additional optional parameters in the constructor syntax of several classes for increased flexibility and functionality.
- Simplified class references in the `azure.storage.blob` module by replacing fully qualified names with class names only. This could be due to direct class imports in the source code or changes in the documentation generation tool.
- Simplified the syntax for the constructor of the `BlobBlock` class by directly using the enum value instead of its string representation.
- Improved code style consistency and readability by removing spaces around the `=` sign when used to indicate a default parameter value, in line with Python's PEP 8 style guide.
- Updated the type definition of `tags` to accept two string parameters instead of one and corrected a syntax error in the original document.
- Added a new method `add_note()` to the `PartialBatchErrorException` class in the Azure Storage Blob SDK.
- Simplified the parameter name in the documentation for `policy_mode` in the `ImmutabilityPolicy` class and added a new type reference, indicating that the source code now allows `policy_mode` to be of type `BlobImmutabilityPolicyMode`.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->